### PR TITLE
feat: Add JEE Rank Analyzer page (Page 3)

### DIFF
--- a/josaa_scraper.py
+++ b/josaa_scraper.py
@@ -1,0 +1,260 @@
+import requests
+from bs4 import BeautifulSoup
+import pandas as pd
+import re
+
+JOSAA_ORCR_URL = "https://josaa.admissions.nic.in/applicant/SeatAllotmentResult/CurrentORCR.aspx"
+
+HEADERS = {
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+    'Referer': JOSAA_ORCR_URL,
+    'Content-Type': 'application/x-www-form-urlencoded',
+    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
+    'Accept-Encoding': 'gzip, deflate, br',
+    'Accept-Language': 'en-US,en;q=0.9'
+}
+
+def fetch_josaa_orcr_data(round_no=4, institute_type="ALL", institute_name="ALL", program_name="ALL", seat_category="ALL"):
+    """
+    Fetches Opening and Closing Rank data from JoSAA website.
+
+    Args:
+        round_no (int): The round number (e.g., 4).
+        institute_type (str): Institute type code (e.g., "ALL", specific codes).
+        institute_name (str): Institute name code (e.g., "ALL", specific codes).
+        program_name (str): Program name code (e.g., "ALL", specific codes).
+        seat_category (str): Seat category code (e.g., "ALL", "OPEN", "EWS").
+
+    Returns:
+        pandas.DataFrame: A DataFrame containing the cleaned ORCR data, or an empty DataFrame on failure.
+    """
+    s = requests.Session()
+    s.headers.update(HEADERS)
+
+    try:
+        # Step 1: Initial GET request to get form parameters
+        print("Fetching initial JoSAA page to get form parameters...")
+        response_get = s.get(JOSAA_ORCR_URL, timeout=20)
+        response_get.raise_for_status()
+        soup = BeautifulSoup(response_get.text, 'lxml')
+
+        viewstate = soup.find('input', {'name': '__VIEWSTATE'})['value']
+        viewstategenerator = soup.find('input', {'name': '__VIEWSTATEGENERATOR'})['value']
+        eventvalidation = soup.find('input', {'name': '__EVENTVALIDATION'})['value']
+
+        print(f"  VIEWSTATE captured (length: {len(viewstate)})")
+        # print(f"  EVENTVALIDATION captured (length: {len(eventvalidation)})")
+
+
+        # Step 2: Construct POST payload
+        # These are typical names for ASP.NET controls. May need adjustment if exact IDs are different.
+        # Based on typical JoSAA structure:
+        # ctl00$ContentPlaceHolder1$ddlroundno -> Round
+        # ctl00$ContentPlaceHolder1$ddlInstype -> Institute Type
+        # ctl00$ContentPlaceHolder1$ddlInstitute -> Institute (ALL can be 'ALL')
+        # ctl00$ContentPlaceHolder1$ddlBranch -> Program (ALL can be 'ALL')
+        # ctl00$ContentPlaceHolder1$ddlSeatType -> Seat Category/Type (ALL can be 'ALL')
+        # ctl00$ContentPlaceHolder1$btnSubmit -> Submit button
+
+        payload = {
+            '__EVENTTARGET': '',
+            '__EVENTARGUMENT': '',
+            '__LASTFOCUS': '',
+            '__VIEWSTATE': viewstate,
+            '__VIEWSTATEGENERATOR': viewstategenerator,
+            '__EVENTVALIDATION': eventvalidation,
+            'ctl00$ContentPlaceHolder1$ddlroundno': str(round_no),
+            'ctl00$ContentPlaceHolder1$ddlInstype': institute_type, # "ALL" or specific code
+            'ctl00$ContentPlaceHolder1$ddlInstitute': institute_name, # "ALL" or specific code
+            'ctl00$ContentPlaceHolder1$ddlBranch': program_name,    # "ALL" or specific code
+            'ctl00$ContentPlaceHolder1$ddlSeatType': seat_category, # "ALL" or specific code
+            'ctl00$ContentPlaceHolder1$btnSubmit': 'Submit'
+        }
+
+        print(f"Submitting POST request for Round {round_no}, InstType: {institute_type}, SeatCat: {seat_category}...")
+        # Step 3: POST request to get the data
+        response_post = s.post(JOSAA_ORCR_URL, data=payload, timeout=60) # Longer timeout for data retrieval
+        response_post.raise_for_status()
+        print("  POST request successful. Parsing HTML table...")
+
+        # Step 4: Parse the HTML table from the response
+        # pandas.read_html usually finds tables well. We might need to select the correct one if multiple exist.
+        # The target table is often identified by an ID like 'ctl00_ContentPlaceHolder1_grdInstlist' or similar.
+        # However, read_html is quite good. Let's try without specific attrs first.
+        dfs = pd.read_html(response_post.text)
+
+        if not dfs:
+            print("  No tables found in the POST response.")
+            return pd.DataFrame()
+
+        # Assuming the main data table is one of the first ones, often the largest.
+        # This might need adjustment based on actual page structure.
+        # A common JoSAA table has columns like 'Institute', 'Academic Program Name', etc.
+        # Let's find a table with a good number of columns, likely the data table.
+        data_df = None
+        for df_candidate in dfs:
+            if df_candidate.shape[1] > 5: # Heuristic: actual data table has more than 5 columns
+                # Check for typical column names if possible (very hard without seeing the exact HTML output)
+                # For now, take the first one that looks plausible
+                data_df = df_candidate
+                break
+
+        if data_df is None:
+            print("  Could not identify the main data table from the parsed HTML.")
+            return pd.DataFrame()
+
+        print(f"  Successfully parsed a table with shape: {data_df.shape}")
+
+        # Step 5: Clean the DataFrame
+        if data_df.empty:
+            print("  Parsed table is empty.")
+            return pd.DataFrame()
+
+        # Expected columns (actual names might vary slightly based on JoSAA HTML):
+        # 'Institute', 'Academic Program Name', 'Quota', 'Seat Type', 'Gender', 'Opening Rank', 'Closing Rank'
+        # The scraper might return slightly different names initially from read_html.
+        # Common column names from JoSAA tables:
+        # Column 0: Institute
+        # Column 1: Academic Program Name
+        # Column 2: Quota
+        # Column 3: Seat Category (like OPEN, EWS, SC, ST, OBC-NCL, OPEN (PwD), etc.)
+        # Column 4: Gender (like Gender-Neutral, Female-only (including Supernumerary))
+        # Column 5: Opening Rank
+        # Column 6: Closing Rank
+
+        # Basic rename if columns are just numbered by pandas.read_html
+        if all(isinstance(col, int) for col in data_df.columns):
+             # Check if the number of columns is what we expect (e.g., 7)
+            if data_df.shape[1] == 7:
+                data_df.columns = ['Institute', 'Program', 'Quota', 'Category', 'Gender', 'OpeningRank', 'ClosingRank']
+            else:
+                print(f"  Parsed table has {data_df.shape[1]} columns, expected 7 for default renaming. Using raw columns.")
+        else: # If columns already have names, try to standardize known ones
+            # This part is tricky as exact names from read_html can vary.
+            # We will rely on the user to verify and potentially map columns in the Streamlit app if needed,
+            # or refine this scraper after seeing the first output.
+            # For now, let's assume the column order is somewhat consistent.
+            # A more robust way is to inspect the actual headers from the HTML table if possible.
+            # For now, we'll do a generic rename if it's a 7-column table.
+             if data_df.shape[1] == 7: # A common structure
+                # Check if first row is header-like and promote it
+                if data_df.iloc[0].astype(str).str.contains('Institute|Program|Quota|Rank', case=False).any():
+                    print("  Promoting first row as header.")
+                    data_df.columns = data_df.iloc[0]
+                    data_df = data_df[1:]
+                    data_df.reset_index(drop=True, inplace=True)
+
+                # Standardize column names based on common patterns
+                rename_map = {}
+                for col in data_df.columns:
+                    col_lower = str(col).lower()
+                    if 'institute' in col_lower: rename_map[col] = 'Institute'
+                    elif 'program' in col_lower: rename_map[col] = 'Program'
+                    elif 'quota' in col_lower: rename_map[col] = 'Quota'
+                    elif 'seat type' in col_lower or 'category' in col_lower: rename_map[col] = 'Category'
+                    elif 'gender' in col_lower: rename_map[col] = 'Gender'
+                    elif 'opening' in col_lower and 'rank' in col_lower: rename_map[col] = 'OpeningRank'
+                    elif 'closing' in col_lower and 'rank' in col_lower: rename_map[col] = 'ClosingRank'
+                data_df.rename(columns=rename_map, inplace=True)
+
+
+        # Convert rank columns to numeric, coercing errors.
+        # JoSAA ranks can be like '1234' or '123P' (PwD closing rank beyond general closing).
+        # For '123P', the 'P' indicates it's a PwD rank. We need to decide how to treat it.
+        # Option 1: Extract numeric part, add a PwD flag column.
+        # Option 2: Treat '...P' as a very high number or NaN if direct comparison is needed.
+        # For now, let's try to extract numeric part and store 'P' separately if needed.
+        # A simpler initial approach: remove 'P' and convert.
+
+        def clean_rank(rank_str):
+            if pd.isna(rank_str):
+                return None
+            s = str(rank_str).strip()
+            if not s: # Handle empty strings
+                return None
+            # Remove " (PwD)" suffix if present from some JoSAA formats
+            s = s.replace(" (PwD)", "")
+            if s.endswith('P'):
+                # For simplicity, removing 'P' and taking the number.
+                # This means '123P' becomes 123. This might not be ideal for strict comparison logic
+                # without knowing the context of 'P' (e.g., if it means rank went into preparatory course).
+                # For now, this is a basic conversion.
+                return pd.to_numeric(s[:-1], errors='coerce')
+            return pd.to_numeric(s, errors='coerce')
+
+        if 'OpeningRank' in data_df.columns:
+            data_df['OpeningRank'] = data_df['OpeningRank'].apply(clean_rank)
+        if 'ClosingRank' in data_df.columns:
+            data_df['ClosingRank'] = data_df['ClosingRank'].apply(clean_rank)
+
+        # Drop rows where essential data might be missing after cleaning (e.g. ranks)
+        if 'ClosingRank' in data_df.columns:
+            data_df.dropna(subset=['ClosingRank', 'OpeningRank'], how='any', inplace=True)
+
+
+        print("  DataFrame cleaned. Final shape:", data_df.shape)
+        return data_df
+
+    except requests.exceptions.Timeout:
+        print(f"Timeout while trying to reach JoSAA website: {JOSAA_ORCR_URL}")
+    except requests.exceptions.RequestException as e:
+        print(f"Request to JoSAA failed: {e}")
+    except Exception as e:
+        print(f"An unexpected error occurred while fetching JoSAA data: {e}")
+
+    return pd.DataFrame()
+
+
+if __name__ == '__main__':
+    print("Attempting to fetch JoSAA ORCR Data for Round 4 (ALL, ALL, ALL, ALL)...")
+    # This will fetch ALL data, which can be very large and slow.
+    # For testing, one might fetch for a specific institute type or category if the website doesn't timeout.
+    # However, the plan is to fetch all and filter in pandas.
+
+    # To make the test faster, let's try for a specific institute type.
+    # Example: "NIT" (National Institute of Technology). The actual code for "NIT" might be like "101" or "I"
+    # This requires knowing the <option value="..."> for "NIT" from the ddlInstype dropdown.
+    # For now, sticking to "ALL" as per the plan, but be aware it's a large fetch.
+
+    # df_josaa = fetch_josaa_orcr_data(round_no=4) # Fetch all data for Round 4
+
+    # A more targeted test for development:
+    # df_josaa = fetch_josaa_orcr_data(round_no=4, institute_type="101", seat_category="OPEN") # Example: NIT, OPEN
+    # The above institute_type "101" is a guess. The actual values need to be known from the JoSAA page source for ddlInstype.
+    # For the initial generic scraper, we rely on "ALL".
+
+    df_josaa = fetch_josaa_orcr_data(round_no=4, institute_type="ALL", institute_name="ALL", program_name="ALL", seat_category="ALL")
+
+
+    if not df_josaa.empty:
+        print("\nJoSAA Data Fetched Successfully:")
+        print(f"Shape: {df_josaa.shape}")
+        print("\nFirst 5 rows:")
+        print(df_josaa.head())
+        print("\nLast 5 rows:")
+        print(df_josaa.tail())
+
+        print("\nInfo:")
+        df_josaa.info()
+
+        if 'Category' in df_josaa.columns:
+            print("\nUnique Categories found:")
+            print(df_josaa['Category'].unique())
+        if 'Quota' in df_josaa.columns:
+            print("\nUnique Quotas found:")
+            print(df_josaa['Quota'].unique())
+        if 'Gender' in df_josaa.columns:
+            print("\nUnique Genders found:")
+            print(df_josaa['Gender'].unique())
+
+        # Check rank columns
+        if 'OpeningRank' in df_josaa.columns and 'ClosingRank' in df_josaa.columns:
+            print("\nRank columns describe:")
+            print(df_josaa[['OpeningRank', 'ClosingRank']].describe())
+            print("\nNulls in rank columns after cleaning:")
+            print(df_josaa[['OpeningRank', 'ClosingRank']].isnull().sum())
+
+    else:
+        print("\nFailed to fetch JoSAA data or data was empty.")
+
+    print("\n--- Scraper Test Complete ---")

--- a/pages/3_jee_analyzer.py
+++ b/pages/3_jee_analyzer.py
@@ -1,0 +1,239 @@
+import streamlit as st
+import pandas as pd
+import sys
+import os
+
+# Ensure the root directory is in sys.path for module imports
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from josaa_scraper import fetch_josaa_orcr_data # Placeholder, will be created
+
+# Page Configuration
+st.set_page_config(layout="wide", page_title="🎓 JEE Rank Analyzer")
+st.title("🎓 JEE Rank Analyzer")
+st.caption("Analyze JoSAA Opening & Closing Ranks to find suitable engineering options.")
+
+st.markdown("---")
+
+# Placeholder for Data Loading section
+st.subheader("Load JoSAA Data")
+
+@st.cache_data(show_spinner="Fetching JoSAA data (Round 4)... This may take a few minutes.")
+def load_josaa_data_round_4():
+    """Calls the scraper to fetch JoSAA data for Round 4 and caches it."""
+    print("Attempting to fetch JoSAA data via scraper...") # For server log
+    df = fetch_josaa_orcr_data(round_no=4) # Default is Round 4, ALL, ALL, ALL
+    if df.empty:
+        print("Fetching returned empty DataFrame.")
+    else:
+        print(f"Fetched DataFrame with shape: {df.shape}")
+    return df
+
+# Button to trigger data loading
+if st.button("Load/Refresh JoSAA Round 4 Data", key="load_josaa_data_btn"):
+    # Clearing specific cache for a function is not direct with new @st.cache_data without changing its args.
+    # For a true refresh, one might add a dummy parameter that changes, or clear all cache.
+    # A simpler approach for now: direct call, relies on user clicking if they want a refresh.
+    # Or, we can remove data from session state to ensure it re-runs and re-assigns.
+    if 'josaa_df' in st.session_state:
+        del st.session_state.josaa_df # Remove old data to ensure re-load if button is pressed
+        st.cache_data.clear() # Clear all cached functions - might be too broad but ensures refresh for this one.
+        st.info("Cache cleared. Re-fetching JoSAA data...")
+
+    josaa_df = load_josaa_data_round_4()
+    if not josaa_df.empty:
+        st.session_state.josaa_df = josaa_df
+        st.success(f"JoSAA Round 4 data loaded successfully! Found {len(josaa_df)} records.")
+        # st.dataframe(st.session_state.josaa_df.head()) # Optional: show a preview
+    else:
+        st.error("Failed to load JoSAA data. The scraper might have encountered an issue. Check server logs.")
+        if 'josaa_df' in st.session_state: # Ensure it's not there if load failed
+            del st.session_state.josaa_df
+
+if 'josaa_df' not in st.session_state:
+    st.warning("JoSAA data not loaded. Click the button above to load it.")
+else:
+    st.info(f"JoSAA data (Round 4) is loaded with {len(st.session_state.josaa_df)} records.")
+
+
+st.markdown("---")
+
+# Placeholder for User Inputs section
+st.subheader("Your Preferences")
+
+# Initialize session state for inputs if they don't exist
+if 'user_rank' not in st.session_state:
+    st.session_state.user_rank = 10000
+if 'user_category' not in st.session_state:
+    st.session_state.user_category = None
+if 'user_quota' not in st.session_state:
+    st.session_state.user_quota = None
+if 'user_gender' not in st.session_state:
+    st.session_state.user_gender = 'Gender-Neutral' # Default
+if 'user_programs' not in st.session_state:
+    st.session_state.user_programs = []
+
+
+if 'josaa_df' in st.session_state and not st.session_state.josaa_df.empty:
+    josaa_df_loaded = st.session_state.josaa_df
+
+    # --- User Inputs ---
+    cols = st.columns(4)
+    with cols[0]:
+        st.session_state.user_rank = st.number_input(
+            "Enter your Category Rank:",
+            min_value=1,
+            value=st.session_state.user_rank,  # Persist value
+            step=1
+        )
+
+    # Dynamically populate Category options
+    available_categories = sorted(josaa_df_loaded['Category'].unique().tolist()) if 'Category' in josaa_df_loaded.columns else []
+    if available_categories:
+        # Ensure previous selection is still valid or reset
+        if st.session_state.user_category not in available_categories:
+            st.session_state.user_category = available_categories[0] if available_categories else None
+        with cols[1]:
+            st.session_state.user_category = st.selectbox(
+                "Select your Category:",
+                options=available_categories,
+                index=available_categories.index(st.session_state.user_category) if st.session_state.user_category in available_categories else 0
+            )
+    else:
+        with cols[1]:
+            st.text("Category: (Load data)")
+
+    # Dynamically populate Quota options
+    available_quotas = sorted(josaa_df_loaded['Quota'].unique().tolist()) if 'Quota' in josaa_df_loaded.columns else []
+    if available_quotas:
+        if st.session_state.user_quota not in available_quotas:
+            st.session_state.user_quota = available_quotas[0] if available_quotas else None
+        with cols[2]:
+            st.session_state.user_quota = st.selectbox(
+                "Select Quota:",
+                options=available_quotas,
+                index=available_quotas.index(st.session_state.user_quota) if st.session_state.user_quota in available_quotas else 0
+            )
+    else:
+        with cols[2]:
+            st.text("Quota: (Load data)")
+
+    with cols[3]:
+        st.session_state.user_gender = st.selectbox(
+            "Select Gender:",
+            options=['Gender-Neutral', 'Female-only (including Supernumerary)'],
+            index=0 if st.session_state.user_gender == 'Gender-Neutral' else 1
+        )
+
+    # Program preference (optional)
+    available_programs = sorted(josaa_df_loaded['Program'].unique().tolist()) if 'Program' in josaa_df_loaded.columns else []
+    if available_programs:
+        st.session_state.user_programs = st.multiselect(
+            "Filter by Program(s) (Optional - leave blank for all):",
+            options=available_programs,
+            default=st.session_state.user_programs # Persist selection
+        )
+    else:
+        st.text("Programs: (Load data to see options)")
+
+    # Store inputs in session state for potential use in filtering logic (though direct use is also fine)
+    # This is already done by assigning to st.session_state.input_X above.
+
+else:
+    st.info("Load JoSAA data to set your preferences.")
+
+
+st.markdown("---")
+
+# Results section
+st.subheader("Matching Options")
+
+if 'josaa_df' in st.session_state and not st.session_state.josaa_df.empty:
+    filtered_df = st.session_state.josaa_df.copy()
+
+    # Apply filters based on user input stored in session state
+    user_rank = st.session_state.user_rank
+    user_category = st.session_state.user_category
+    user_quota = st.session_state.user_quota
+    user_gender = st.session_state.user_gender
+    user_programs = st.session_state.user_programs
+
+    # 1. Filter by Category
+    if user_category and 'Category' in filtered_df.columns:
+        filtered_df = filtered_df[filtered_df['Category'] == user_category]
+
+    # 2. Filter by Quota
+    if user_quota and 'Quota' in filtered_df.columns:
+        filtered_df = filtered_df[filtered_df['Quota'] == user_quota]
+
+    # 3. Filter by Rank (ClosingRank >= User's Rank)
+    # Ensure 'ClosingRank' is numeric. Scraper attempts this.
+    if 'ClosingRank' in filtered_df.columns:
+        # Convert user_rank to float for comparison, assuming ClosingRank is float/int
+        filtered_df['ClosingRank'] = pd.to_numeric(filtered_df['ClosingRank'], errors='coerce')
+        filtered_df = filtered_df[filtered_df['ClosingRank'] >= float(user_rank)]
+    else:
+        st.warning("Warning: 'ClosingRank' column not found. Cannot filter by rank.")
+
+    # 4. Filter by Gender
+    # This assumes the 'Gender' column from the scraper contains 'Gender-Neutral' or 'Female-only (including Supernumerary)'
+    if user_gender and 'Gender' in filtered_df.columns:
+        if user_gender == 'Female-only (including Supernumerary)':
+            # Exact match for female-only seats
+            filtered_df = filtered_df[filtered_df['Gender'] == 'Female-only (including Supernumerary)']
+        elif user_gender == 'Gender-Neutral':
+            # For Gender-Neutral, we typically consider seats explicitly marked Gender-Neutral.
+            # Some interpretations might include Female-Only seats too if a female is searching under Gender-Neutral,
+            # but JoSAA data usually distinguishes these. So, exact match for "Gender-Neutral".
+            filtered_df = filtered_df[filtered_df['Gender'] == 'Gender-Neutral']
+        # If 'Gender' column has other values or this logic needs refinement, it will be seen in testing.
+    elif 'Gender' not in filtered_df.columns:
+         st.warning("Warning: 'Gender' column not found in JoSAA data. Cannot filter by gender.")
+
+
+    # 5. Filter by Program (if any selected)
+    if user_programs and 'Program' in filtered_df.columns: # user_programs is a list from multiselect
+        filtered_df = filtered_df[filtered_df['Program'].isin(user_programs)]
+
+    if not filtered_df.empty:
+        st.write(f"Found {len(filtered_df)} matching options based on your preferences:")
+
+        # Sort by Closing Rank by default
+        # Ensure 'ClosingRank' is numeric for sorting; it should be from previous step's coercion
+        if 'ClosingRank' in filtered_df.columns:
+            # Convert again just in case, or rely on previous coercion
+            filtered_df['ClosingRank'] = pd.to_numeric(filtered_df['ClosingRank'], errors='coerce')
+            # Handle NaNs in sorting, e.g., place them last or first depending on preference
+            # For ranks, NaNs likely mean data issue or 'P' was not fully converted. Assuming NaNs are not desirable to see first.
+            sorted_df = filtered_df.sort_values(by='ClosingRank', ascending=True, na_position='last')
+        else:
+            sorted_df = filtered_df # Cannot sort if column is missing
+
+        # Define columns to display in the main table
+        display_columns = ['Institute', 'Program', 'Quota', 'Category', 'OpeningRank', 'ClosingRank']
+        # Ensure these columns exist in the dataframe
+        existing_display_columns = [col for col in display_columns if col in sorted_df.columns]
+
+        if not existing_display_columns:
+            st.warning("The expected columns for display (Institute, Program, etc.) are not available in the filtered data.")
+            st.dataframe(sorted_df, use_container_width=True) # Show raw if no standard columns
+        else:
+            st.dataframe(sorted_df[existing_display_columns], use_container_width=True)
+
+        with st.expander("View all columns for filtered results"):
+            st.dataframe(sorted_df, use_container_width=True)
+
+    else:
+        st.info("No matching options found for your current criteria. Try adjusting your preferences or rank.")
+
+else:
+    st.info("Load JoSAA data and set your preferences to see matching options.")
+
+
+st.markdown("---")
+
+# Placeholder for Results section
+st.subheader("Matching Options")
+st.write("Filtered and sorted college/program options will be displayed here.")
+
+st.markdown("---")
+st.info("This page is under active development. Full functionality coming soon!")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,6 @@ streamlit
 yfinance
 spacy
 requests
+beautifulsoup4
+lxml
 # Add other specific versions if needed, e.g., streamlit==1.20.0


### PR DESCRIPTION
- Created `josaa_scraper.py` to fetch and parse JoSAA Opening/Closing Rank data for Round 4 from the official website, handling ASP.NET form intricacies.
- Added `pages/3_jee_analyzer.py` for the new JEE Rank Analyzer tool.
- Implemented data loading with `st.cache_data` for scraped JoSAA data, including a refresh button.
- Added user inputs for Category Rank, Category, Quota, Gender, and optional Program preferences. Dropdowns are dynamically populated from the data.
- Implemented filtering logic to find matching college/program options based on user inputs.
- Displays results in a sortable table (default sort by Closing Rank) with relevant columns and an expander for all details.
- Updated `requirements.txt` with `beautifulsoup4` and `lxml`.